### PR TITLE
Add the option to mass index elements with a command.

### DIFF
--- a/algolia/config.php
+++ b/algolia/config.php
@@ -16,4 +16,12 @@ return [
      */
     'indices' => [],
 
+    /**
+     * Batch limit
+     *
+     * @var integer
+     */
+    'limit' => 100,
+
+
 ];

--- a/algolia/consolecommands/AlgoliaCommand.php
+++ b/algolia/consolecommands/AlgoliaCommand.php
@@ -1,0 +1,98 @@
+<?php
+namespace Craft;
+
+class AlgoliaCommand extends BaseCommand
+{
+    public function actionImport($indice = -1, $page = 0)
+    {
+
+        if($indice < 0){
+
+            $this->writeLog('Starting Algolia importation.');
+
+            foreach (craft()->algolia->getIndicies() as $indexName => $index) {
+
+                $this->writeLog('Importing indice '. $indexName);
+                $command = strtr('php {script} algolia import --indice="{indice}" --page="{page}"', [
+                    '{script}' => $this->getCommandRunner()->getScriptName(),
+                    '{indice}' => ++$indice,
+                    '{page}' => 0
+                ]);
+
+                passthru($command);
+            }
+
+            $this->writeLog('Import done.');
+
+            return craft()->end();
+        }
+
+        $pageInfo = $this->paginateImportation($indice);
+
+        foreach($pageInfo['pages'] as $page)
+        {
+            $this->writeLog('Importing page ' .( $page +1 ). '/'.$pageInfo['totalPages']. ' of index '.$indice );
+
+            $command = strtr('php {script} algolia importIndicePage --indice="{indice}" --page="{page}"', [
+                '{script}' => $this->getCommandRunner()->getScriptName(),
+                '{indice}' => $indice,
+                '{page}' => $page
+            ]);
+
+            passthru($command);
+        }
+
+        craft()->end();
+
+    }
+
+    public function actionImportIndicePage($indice, $page)
+    {
+        craft()->algolia->import($indice, $page);
+    }
+
+    private function paginateImportation($index)
+    {
+        $limit = craft()->config->get('limit', 'algolia');
+
+        $currentIndex = array_slice(craft()->algolia->getIndicies(), $index, 1);
+        $currentIndex = array_shift($currentIndex);
+
+        $criteria = craft()->elements->getCriteria(ucfirst($currentIndex->elementType), $currentIndex->elementCriterias);
+        $criteria->status = null;
+        $criteria->limit = null;
+        $total = $criteria->total();
+
+        $this->writeLog( 'Total elements ' . $total);
+
+        $totalPages = ceil( $total / $limit );
+
+        return ['totalPages' => $totalPages, 'pages'=>range(0, $totalPages)];
+
+    }
+
+    private function write($str)
+    {
+        echo $str;
+    }
+
+    private function writeLn($str = '')
+    {
+        echo (is_array($str) ? implode(PHP_EOL, $str) : $str) . PHP_EOL;
+    }
+
+    private function writeLog($str, $ln = true)
+    {
+        $now = new DateTime('now');
+
+        $log = sprintf(
+            '%s - %s (%s M)',
+            $now->mySqlDateTime(),
+            is_array($str) ? implode(PHP_EOL, $str) : $str,
+            round(memory_get_usage() / 1024 / 1024, 2)
+        );
+
+        $ln ? $this->writeLn($log) : $this->write($log);
+    }
+
+}

--- a/algolia/models/Algolia_IndexModel.php
+++ b/algolia/models/Algolia_IndexModel.php
@@ -88,6 +88,37 @@ class Algolia_IndexModel extends BaseModel
     }
 
     /**
+     * Adds or removes the supplied elements from the index.
+     *
+     * @param $elements array
+     *
+     * @return mixed
+     */
+    public function indexElements($elements)
+    {
+
+        $toIndex = [];
+        $toDelete = [];
+
+        array_map(function($element) use (&$toIndex, &$toDelete){
+            if ($this->canIndexElement($element)) {
+                if ($element->enabled) {
+                    $toIndex[] = $this->transformElement($element);
+                } else {
+                    $toDelete[] = $this->transformElement($element);
+                }
+            }
+
+        }, $elements);
+
+        $this->getAlgoliaIndex()->addObjects($toIndex);
+        $this->getAlgoliaIndex()->deleteObjects($toDelete);
+
+        return true;
+
+    }
+
+    /**
      * Returns the index name with the configured prefix.
      *
      * @return string
@@ -104,6 +135,10 @@ class Algolia_IndexModel extends BaseModel
     {
         return [
             'indexName' => AttributeType::String,
+            'elementCriterias' => [
+                AttributeType::Mixed,
+                'default' => null
+            ],
             'elementType' => [
                 AttributeType::String,
                 'default' => ElementType::Entry,

--- a/algolia/services/AlgoliaService.php
+++ b/algolia/services/AlgoliaService.php
@@ -109,4 +109,36 @@ class AlgoliaService extends BaseApplicationComponent
             $index->indexElement($element);
         }
     }
+
+    /**
+     * Passes the supplied elements to each configured index.
+     *
+     * @param $element array
+     */
+    public function indexElements($elements)
+    {
+        foreach ($this->getIndicies() as $indexName => $index) {
+            $index->indexElements($elements);
+        }
+    }
+
+    /**
+     * Imports a paginated batch
+     *
+     * @param $page integer
+     */
+    public function import($index, $page = 0) 
+    {
+        $limit = craft()->config->get('limit', 'algolia');
+
+        $currentIndex = array_slice(craft()->algolia->getIndicies(), $index, 1);
+        $currentIndex = array_shift($currentIndex);
+
+        $criteria = craft()->elements->getCriteria(ucfirst($currentIndex->elementType), $currentIndex->elementCriterias);
+        $criteria->limit = $limit;
+        $criteria->offset = $page * $limit;
+
+        return $this->indexElements($criteria->find());
+        
+    }
 }


### PR DESCRIPTION
I've added the option to mass index elements through a command.

I had this need when installing the plugin on an existing project.

I added an "elementCriterias' array in the config that will be passed to the critieria itself to help filter down results.

`'elementCriterias' => [
                'section' => [
                    'section-name', 'news', 'homepage',
                ]
            ],`

You can pass any value as you would do with the ElementCritieraModel.

Each iteration batched by the limit variable will be passed to a child process to ensure we never run out of memory.  